### PR TITLE
Fix HKCAZ to only include iban and bic

### DIFF
--- a/src/dataGroups/CamtAccount.ts
+++ b/src/dataGroups/CamtAccount.ts
@@ -1,0 +1,23 @@
+import { AlphaNumeric } from '../dataElements/AlphaNumeric.js';
+import { DataGroup } from './DataGroup.js';
+
+export type CamtAccount = {
+    iban?: string;
+    bic?: string;
+};
+
+export class CamtAccountGroup extends DataGroup {
+    constructor(name: string, minCount = 0, maxCount = 1, minVersion?: number, maxVersion?: number) {
+        super(
+            name,
+            [
+                new AlphaNumeric('iban', 0, 1, 34),
+                new AlphaNumeric('bic', 0, 1, 11),
+            ],
+            minCount,
+            maxCount,
+            minVersion,
+            maxVersion,
+        );
+    }
+}

--- a/src/interactions/statementInteractionCAMT.ts
+++ b/src/interactions/statementInteractionCAMT.ts
@@ -53,7 +53,13 @@ export class StatementInteractionCAMT extends CustomerOrderInteraction {
 				// Parse all CAMT messages (one per booking day) and combine statements
 				const allStatements: Statement[] = [];
 				for (const camtMessage of hicaz.bookedTransactions) {
-					const parser = new CamtParser(camtMessage);
+
+                    // camtMessage is initially encoded as 'latin1' (ISO-8859-1), but actually contains UTF-8 data.
+                    // Therefore, we need to first convert it back to a buffer using 'latin1', and then decode it as 'utf8'.
+                    const intermediateBuffer = Buffer.from(camtMessage, 'latin1');
+                    const utf8String = intermediateBuffer.toString('utf8');
+
+                    const parser = new CamtParser(utf8String);
 					const statements = parser.parse();
 					allStatements.push(...statements);
 				}

--- a/src/segments/HKCAZ.ts
+++ b/src/segments/HKCAZ.ts
@@ -4,15 +4,12 @@ import { Numeric } from '../dataElements/Numeric.js';
 import { Text } from '../dataElements/Text.js';
 import { YesNo } from '../dataElements/YesNo.js';
 import { DataGroup } from '../dataGroups/DataGroup.js';
-import {
-	type InternationalAccount,
-	InternationalAccountGroup,
-} from '../dataGroups/InternationalAccount.js';
 import type { SegmentWithContinuationMark } from '../segment.js';
 import { SegmentDefinition } from '../segmentDefinition.js';
+import {CamtAccount, CamtAccountGroup} from "../dataGroups/CamtAccount.js";
 
 export type HKCAZSegment = SegmentWithContinuationMark & {
-	account: InternationalAccount;
+	account: CamtAccount;
 	acceptedCamtFormats: string[];
 	allAccounts: boolean;
 	from?: Date;
@@ -31,7 +28,7 @@ export class HKCAZ extends SegmentDefinition {
 	}
 	version = HKCAZ.Version;
 	elements = [
-		new InternationalAccountGroup('account', 1, 1),
+		new CamtAccountGroup('account', 1, 1),
 		new DataGroup('acceptedCamtFormats', [new Text('camtFormat', 1, 99)], 1, 1), // Support multiple camt-formats
 		new YesNo('allAccounts', 1, 1),
 		new Dat('from', 0, 1),

--- a/src/tests/HKCAZ.test.ts
+++ b/src/tests/HKCAZ.test.ts
@@ -12,8 +12,6 @@ describe('HKCAZ v1', () => {
 			account: {
 				iban: 'DE991234567123456',
 				bic: 'BANK12',
-				accountNumber: '123456',
-				bank: { country: 280, bankId: '12030000' },
 			},
 			acceptedCamtFormats: ['urn:iso:std:iso:20022:tech:xsd:camt.052.001.08'],
 			allAccounts: false,
@@ -22,7 +20,7 @@ describe('HKCAZ v1', () => {
 		};
 
 		expect(encode(segment)).toBe(
-			"HKCAZ:1:1+DE991234567123456:BANK12:123456::280:12030000+urn?:iso?:std?:iso?:20022?:tech?:xsd?:camt.052.001.08+N+20230101+20231231'",
+			"HKCAZ:1:1+DE991234567123456:BANK12+urn?:iso?:std?:iso?:20022?:tech?:xsd?:camt.052.001.08+N+20230101+20231231'",
 		);
 	});
 
@@ -32,21 +30,19 @@ describe('HKCAZ v1', () => {
 			account: {
 				iban: 'DE991234567123456',
 				bic: 'BANK12',
-				accountNumber: '123456',
-				bank: { country: 280, bankId: '12030000' },
 			},
 			acceptedCamtFormats: ['urn:iso:std:iso:20022:tech:xsd:camt.052.001.08'],
 			allAccounts: true,
 		};
 
 		expect(encode(segment)).toBe(
-			"HKCAZ:2:1+DE991234567123456:BANK12:123456::280:12030000+urn?:iso?:std?:iso?:20022?:tech?:xsd?:camt.052.001.08+J'",
+			"HKCAZ:2:1+DE991234567123456:BANK12+urn?:iso?:std?:iso?:20022?:tech?:xsd?:camt.052.001.08+J'",
 		);
 	});
 
 	it('decode and encode roundtrip matches', () => {
 		const text =
-			"HKCAZ:0:1+DE991234567123456:BANK12:123456::280:12030000+urn?:iso?:std?:iso?:20022?:tech?:xsd?:camt.052.001.08+N+20230101+20231231'";
+			"HKCAZ:0:1+DE991234567123456:BANK12+urn?:iso?:std?:iso?:20022?:tech?:xsd?:camt.052.001.08+N+20230101+20231231'";
 		const segment = decode(text);
 		expect(encode(segment)).toBe(text);
 	});

--- a/src/tests/camtParser.test.ts
+++ b/src/tests/camtParser.test.ts
@@ -1008,7 +1008,7 @@ describe('CamtParser', () => {
                             <Ustrd>2ABCDEF9GHIJKL28</Ustrd>
                             <Ustrd>CORE / Mandatsref.:</Ustrd>
                             <Ustrd>7829857lkklag</Ustrd>
-                            <Ustrd>GlÃ¤ubiger-ID:</Ustrd>
+                            <Ustrd>Gläubiger-ID:</Ustrd>
                             <Ustrd>DE24ABC00000123456</Ustrd>
                         </RmtInf>
                     </TxDtls>
@@ -1033,7 +1033,7 @@ describe('CamtParser', () => {
         expect(transaction.customerReference).toBe('');
         expect(transaction.bankReference).toBe('5J2C21XL0470L56V/39761');
         expect(transaction.purpose).toBe(
-            '028-1234567-XXXXXXX Amazon.de 2ABCD\nEF9GFP28\nEnd-to-End-Ref.:\n2ABCDEF9GHIJKL28\nCORE / Mandatsref.:\n7829857lkklag\nGlÃ¤ubiger-ID:\nDE24ABC00000123456',
+            '028-1234567-XXXXXXX Amazon.de 2ABCD\nEF9GFP28\nEnd-to-End-Ref.:\n2ABCDEF9GHIJKL28\nCORE / Mandatsref.:\n7829857lkklag\nGläubiger-ID:\nDE24ABC00000123456',
         );
         expect(transaction.remoteName).toBe('AMAZON EU S.A R.L., NIEDERL ASSUNG DEUTSCHLAND');
         expect(transaction.remoteAccountNumber).toBe('');

--- a/src/tests/camtParser.test.ts
+++ b/src/tests/camtParser.test.ts
@@ -729,8 +729,8 @@ describe('CamtParser', () => {
 		expect(transaction.amount).toBe(200.0);
 	});
 
-	it('should handle multiple entries in RmtInf (Ustrd)', () => {
-		const camtXml = `<?xml version="1.0" encoding="ISO-8859-1"?>
+    it('should handle multiple entries in RmtInf (Ustrd)', () => {
+        const camtXml = `<?xml version="1.0" encoding="ISO-8859-1"?>
 <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.08"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.052.001.08 camt.052.001.08.xsd">
@@ -878,50 +878,191 @@ describe('CamtParser', () => {
   </BkToCstmrAcctRpt>
 </Document>`;
 
-		const parser = new CamtParser(camtXml);
-		const statements = parser.parse();
+        const parser = new CamtParser(camtXml);
+        const statements = parser.parse();
 
-		expect(statements).toHaveLength(1);
-		const statement = statements[0];
-		expect(statement.transactions).toHaveLength(1);
+        expect(statements).toHaveLength(1);
+        const statement = statements[0];
+        expect(statement.transactions).toHaveLength(1);
 
-		const transaction = statement.transactions[0];
+        const transaction = statement.transactions[0];
 
-		// Check all Transaction fields filled by the parser
-		expect(transaction.amount).toBe(-179.46);
-		expect(transaction.customerReference).toBe('VG 2025 QUARTAL IV');
-		expect(transaction.bankReference).toBe('TXN003');
-		expect(transaction.purpose).toBe(
-			'28,65EUR EREF: VG 2025 QUARTAL IV IBAN: DE12345678901234567891 BIC: BANKABC1XXX',
-		);
-		expect(transaction.remoteName).toBe('ABC Bank');
-		expect(transaction.remoteAccountNumber).toBe('DE12345678901234567891');
-		expect(transaction.remoteBankId).toBe('BANKABC1XXX');
-		expect(transaction.e2eReference).toBe('VG 2025 QUARTAL IV');
+        // Check all Transaction fields filled by the parser
+        expect(transaction.amount).toBe(-179.46);
+        expect(transaction.customerReference).toBe('VG 2025 QUARTAL IV');
+        expect(transaction.bankReference).toBe('TXN003');
+        expect(transaction.purpose).toBe(
+            '28,65EUR EREF: VG 2025 QUARTAL IV IBAN\n: DE12345678901234567891 BIC: BANKABC1XXX',
+        );
+        expect(transaction.remoteName).toBe('ABC Bank');
+        expect(transaction.remoteAccountNumber).toBe('DE12345678901234567891');
+        expect(transaction.remoteBankId).toBe('BANKABC1XXX');
+        expect(transaction.e2eReference).toBe('VG 2025 QUARTAL IV');
 
-		// Check date fields
-		expect(transaction.valueDate).toBeInstanceOf(Date);
-		expect(transaction.valueDate.getFullYear()).toBe(2026);
-		expect(transaction.valueDate.getMonth()).toBe(0); // November (0-based)
-		expect(transaction.valueDate.getDate()).toBe(5);
-		expect(transaction.entryDate).toBeInstanceOf(Date);
-		expect(transaction.entryDate.getFullYear()).toBe(2026);
-		expect(transaction.entryDate.getMonth()).toBe(0); // November (0-based)
-		expect(transaction.entryDate.getDate()).toBe(5);
+        // Check date fields
+        expect(transaction.valueDate).toBeInstanceOf(Date);
+        expect(transaction.valueDate.getFullYear()).toBe(2026);
+        expect(transaction.valueDate.getMonth()).toBe(0); // November (0-based)
+        expect(transaction.valueDate.getDate()).toBe(5);
+        expect(transaction.entryDate).toBeInstanceOf(Date);
+        expect(transaction.entryDate.getFullYear()).toBe(2026);
+        expect(transaction.entryDate.getMonth()).toBe(0); // November (0-based)
+        expect(transaction.entryDate.getDate()).toBe(5);
 
-		// Check transaction type and code fields
-		expect(transaction.fundsCode).toBe('PMNT');
-		expect(transaction.transactionType).toBe('ICDT');
-		expect(transaction.transactionCode).toBe('ESCT');
+        // Check transaction type and code fields
+        expect(transaction.fundsCode).toBe('PMNT');
+        expect(transaction.transactionType).toBe('ICDT');
+        expect(transaction.transactionCode).toBe('ESCT');
 
-		// Check additional information fields
-		expect(transaction.additionalInformation).toBe('ENTGELT gem. Vereinbarung');
-		expect(transaction.bookingText).toBe('ENTGELT gem. Vereinbarung'); // Should match additionalInformation
+        // Check additional information fields
+        expect(transaction.additionalInformation).toBe('ENTGELT gem. Vereinbarung');
+        expect(transaction.bookingText).toBe('ENTGELT gem. Vereinbarung'); // Should match additionalInformation
 
-		// Verify optional fields not set in this test
-		expect(transaction.primeNotesNr).toBeUndefined();
-		expect(transaction.remoteIdentifier).toBeUndefined();
-		expect(transaction.client).toBeUndefined();
-		expect(transaction.textKeyExtension).toBeUndefined();
-	});
+        // Verify optional fields not set in this test
+        expect(transaction.primeNotesNr).toBeUndefined();
+        expect(transaction.remoteIdentifier).toBeUndefined();
+        expect(transaction.client).toBeUndefined();
+        expect(transaction.textKeyExtension).toBeUndefined();
+    });
+
+    it('should handle full iso date time in value date', () => {
+        // this is an example from comdirect bank in 2026-01
+        const camtXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+    <BkToCstmrAcctRpt>
+        <GrpHdr>
+            <MsgId>BD5F4D36X95740C4B89D967367217C16</MsgId>
+            <CreDtTm>2026-01-22T10:35:25.369+01:00</CreDtTm>
+            <MsgPgntn>
+                <PgNb>0</PgNb>
+                <LastPgInd>true</LastPgInd>
+            </MsgPgntn>
+        </GrpHdr>
+        <Rpt>
+            <Id>563916B991DD4EB18894EF4ABB730A5C</Id>
+            <FrToDt>
+                <FrDtTm>2025-12-10T00:00:00.000+01:00</FrDtTm>
+                <ToDtTm>2026-01-22T00:00:00.000+01:00</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <IBAN>DE06940594210000027227</IBAN>
+                </Id>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">94.010000000021</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <DtTm>2025-12-10T00:00:00.000+01:00</DtTm>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">101.960000000017</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <DtTm>2026-01-22T00:00:00.000+01:00</DtTm>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <NtryRef>5J3C21XL0470L56V/39761</NtryRef>
+                <Amt Ccy="EUR">101.5</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2025-12-10+01:00</Dt>
+                </BookgDt>
+                <ValDt>
+                    <DtTm>2025-12-10T00:00:00.000+01:00</DtTm>
+                </ValDt>
+                <AcctSvcrRef>5J2C21XL0470L56V/39761</AcctSvcrRef>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>005</Cd>
+                        <Issr></Issr>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>AMAZON EU S.A R.L., NIEDERL ASSUNG DEUTSCHLAND</Nm>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id/>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RmtInf>
+                            <Ustrd>028-1234567-XXXXXXX Amazon.de 2ABCD</Ustrd>
+                            <Ustrd>EF9GFP28</Ustrd>
+                            <Ustrd>End-to-End-Ref.:</Ustrd>
+                            <Ustrd>2ABCDEF9GHIJKL28</Ustrd>
+                            <Ustrd>CORE / Mandatsref.:</Ustrd>
+                            <Ustrd>7829857lkklag</Ustrd>
+                            <Ustrd>GlÃ¤ubiger-ID:</Ustrd>
+                            <Ustrd>DE24ABC00000123456</Ustrd>
+                        </RmtInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Rpt>
+    </BkToCstmrAcctRpt>
+</Document>
+`;
+
+        const parser = new CamtParser(camtXml);
+        const statements = parser.parse();
+
+        expect(statements).toHaveLength(1);
+        const statement = statements[0];
+        expect(statement.transactions).toHaveLength(1);
+
+        const transaction = statement.transactions[0];
+
+        // Check all Transaction fields filled by the parser
+        expect(transaction.amount).toBe(-101.5);
+        expect(transaction.customerReference).toBe('');
+        expect(transaction.bankReference).toBe('5J2C21XL0470L56V/39761');
+        expect(transaction.purpose).toBe(
+            '028-1234567-XXXXXXX Amazon.de 2ABCD\nEF9GFP28\nEnd-to-End-Ref.:\n2ABCDEF9GHIJKL28\nCORE / Mandatsref.:\n7829857lkklag\nGlÃ¤ubiger-ID:\nDE24ABC00000123456',
+        );
+        expect(transaction.remoteName).toBe('AMAZON EU S.A R.L., NIEDERL ASSUNG DEUTSCHLAND');
+        expect(transaction.remoteAccountNumber).toBe('');
+        expect(transaction.remoteBankId).toBe('');
+        expect(transaction.e2eReference).toBe('');
+
+        // Check date fields
+        expect(transaction.valueDate).toBeInstanceOf(Date);
+        expect(transaction.valueDate.getFullYear()).toBe(2025);
+        expect(transaction.valueDate.getMonth()).toBe(11); // November (0-based)
+        expect(transaction.valueDate.getDate()).toBe(10);
+        expect(transaction.entryDate).toBeInstanceOf(Date);
+        expect(transaction.entryDate.getFullYear()).toBe(2025);
+        expect(transaction.entryDate.getMonth()).toBe(11); // November (0-based)
+        expect(transaction.entryDate.getDate()).toBe(10);
+
+        // Check transaction type and code fields
+        expect(transaction.fundsCode).toBe('DBIT');
+        expect(transaction.transactionType).toBe('');
+        expect(transaction.transactionCode).toBe('');
+
+        // Check additional information fields
+        expect(transaction.additionalInformation).toBe('');
+        expect(transaction.bookingText).toBe(''); // Should match additionalInformation
+
+        // Verify optional fields not set in this test
+        expect(transaction.primeNotesNr).toBeUndefined();
+        expect(transaction.remoteIdentifier).toBeUndefined();
+        expect(transaction.client).toBeUndefined();
+        expect(transaction.textKeyExtension).toBeUndefined();
+    });
 });


### PR DESCRIPTION
Having more than iban and bic in the segment fails at comdirect bank. Fixed by having a specific data element for just having those two values.
Also enhanced camtParser for other date and date time formats.
Fixed statementInteractionCAMT to re-decode the camtMessage as UTF-8 to get purpose text with German umlauts correctly.